### PR TITLE
PC版Chromeで動画が再生されない不具合を修正

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -572,7 +572,7 @@ a img{
 .video-container video {
   position: absolute;
   z-index: 0;
-  bottom: 0;
+  top:0px;
 }
 .video-container video.fillWidth {
   width: 100%;

--- a/js/script.js
+++ b/js/script.js
@@ -6,15 +6,15 @@ $(document).ready(function () {
 		bgColor: '#34495e',
 		spinner: 'spinner4'
 	});
-
-	scaleVideoContainer();
-
 	initBannerVideoSize('.video-container .poster img');
 	initBannerVideoSize('.video-container .filter');
-	initBannerVideoSize('.video-container video');
+  initBannerVideoSize('.video-container video');
+
+  setTimeout(function () {
+    document.getElementsByTagName('video')[0].play();
+  }, 3500);
 
 	$(window).on('resize', function () {
-		scaleVideoContainer();
 		scaleBannerVideoSize('.video-container .poster img');
 		scaleBannerVideoSize('.video-container .filter');
 		scaleBannerVideoSize('.video-container video');
@@ -22,16 +22,7 @@ $(document).ready(function () {
 
 });
 
-function scaleVideoContainer() {
-
-	var height = $(window).height() + 5;
-	var unitHeight = parseInt(height) + 'px';
-	$('.homepage-hero-module').css('height', unitHeight);
-
-}
-
 function initBannerVideoSize(element) {
-
 	$(element).each(function () {
 		$(this).data('height', $(this).height());
 		$(this).data('width', $(this).width());
@@ -46,20 +37,20 @@ function scaleBannerVideoSize(element) {
 	var windowWidth = $(window).width(),
 		windowHeight = $(window).height() + 5,
 		videoWidth,
-		videoHeight;
-
-	// console.log(windowHeight);
+    videoHeight;
 
 	$(element).each(function () {
 		var videoAspectRatio = $(this).data('height') / $(this).data('width');
 
-		$(this).width(windowWidth);
+    $(this).width(windowWidth);
+    $('.homepage-hero-module').css('height', (windowWidth*videoAspectRatio)+'px');
 
 		if (windowWidth < 1000) {
 			videoHeight = windowHeight;
 			videoWidth = videoHeight / videoAspectRatio;
 			$(this).css({ 'margin-top': 0, 'margin-left': -(videoWidth - windowWidth) / 2 + 'px' });
 
+      $('.homepage-hero-module').css('height', videoHeight + 'px');
 			$(this).width(videoWidth).height(videoHeight);
 		}
 


### PR DESCRIPTION
PC版Chromeでは、背景の動画が止まっていた。
`setTimeout` で`play()` を実行することで解決
タブレット、モバイルのChromeでは、動画が表示されず、黒い画面のままなので、要修正